### PR TITLE
Fix duplicate contactInfo declaration causing syntax error

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -802,7 +802,6 @@ function generateFullPlanningBooklet() {
   y = 50;
   
   // Contact Information Section
-  const contactInfo = JSON.parse(localStorage.getItem('contact-info') || '{}');
   if (contactInfo.phone || contactInfo.email || contactInfo.address || contactInfo.hours) {
     doc.setFillColor(30, 58, 138); // Catholic blue
     doc.rect(10, y-8, 190, 10, 'F');


### PR DESCRIPTION
- Removed duplicate 'const contactInfo' declaration in generateFullPlanningBooklet function
- Fixed JavaScript syntax error that was preventing the application from running
- All contact information functionality now works properly